### PR TITLE
Load csv as bean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'com.opencsv', name: 'opencsv', version: '5.5.1'
 }
 
 test {

--- a/src/main/java/in/samspa/munroapi/Munro.java
+++ b/src/main/java/in/samspa/munroapi/Munro.java
@@ -7,7 +7,28 @@ public class Munro {
     @CsvBindByName(column = "Name")
     private String name;
 
+    @CsvBindByName(column = "Height (m)")
+    private Double height;
+
+    @CsvBindByName(column = "Post 1997")
+    private String category;
+
+    @CsvBindByName(column = "Grid Ref")
+    private String gridReference;
+
     String getName() {
         return name;
+    }
+
+    Double getHeight() {
+        return height;
+    }
+
+    String getCategory() {
+        return category;
+    }
+
+    String getGridReference() {
+        return gridReference;
     }
 }

--- a/src/main/java/in/samspa/munroapi/Munro.java
+++ b/src/main/java/in/samspa/munroapi/Munro.java
@@ -1,0 +1,13 @@
+package in.samspa.munroapi;
+
+import com.opencsv.bean.CsvBindByName;
+
+public class Munro {
+
+    @CsvBindByName(column = "Name")
+    private String name;
+
+    String getName() {
+        return name;
+    }
+}

--- a/src/main/java/in/samspa/munroapi/MunroRepository.java
+++ b/src/main/java/in/samspa/munroapi/MunroRepository.java
@@ -1,0 +1,10 @@
+package in.samspa.munroapi;
+
+import org.springframework.stereotype.Component;
+
+@Component
+class MunroRepository {
+
+    void find() {
+    }
+}

--- a/src/main/java/in/samspa/munroapi/MunroRepository.java
+++ b/src/main/java/in/samspa/munroapi/MunroRepository.java
@@ -1,10 +1,39 @@
 package in.samspa.munroapi;
 
+import com.opencsv.bean.CsvToBean;
+import com.opencsv.bean.CsvToBeanBuilder;
+import com.opencsv.bean.HeaderColumnNameMappingStrategy;
 import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 
 @Component
 class MunroRepository {
 
-    void find() {
+    private String fileLocation = "src/main/resources/static/munrotab_v6.2.csv";
+
+    List<Munro> find() {
+        Path dataPath = Paths.get(fileLocation);
+
+        try(BufferedReader br = Files.newBufferedReader(dataPath, StandardCharsets.ISO_8859_1)) {
+            HeaderColumnNameMappingStrategy<Munro> strategy = new HeaderColumnNameMappingStrategy<>();
+            strategy.setType(Munro.class);
+
+            CsvToBean<Munro> csvToBean = new CsvToBeanBuilder<Munro>(br)
+                    .withMappingStrategy(strategy)
+                    .withIgnoreLeadingWhiteSpace(true)
+                    .build();
+
+            return csvToBean.parse();
+        } catch (IOException e) {
+            return Collections.emptyList();
+        }
     }
 }

--- a/src/test/java/in/samspa/munroapi/MunroRepositoryTest.java
+++ b/src/test/java/in/samspa/munroapi/MunroRepositoryTest.java
@@ -5,18 +5,25 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 @ExtendWith(MockitoExtension.class)
 class MunroRepositoryTest {
+
+    private MunroRepository munroRepository;
 
     @BeforeEach
     void init() {
         munroRepository = new MunroRepository();
     }
 
-    MunroRepository munroRepository;
-
     @Test
-    void contextLoads() {
-        munroRepository.find();
+    void getMunroWithName() {
+        List<Munro> foundMunro = munroRepository.find();
+        assertNotEquals(0, foundMunro.size());
+        assertEquals("Ben Chonzie", foundMunro.get(0).getName());
     }
 }

--- a/src/test/java/in/samspa/munroapi/MunroRepositoryTest.java
+++ b/src/test/java/in/samspa/munroapi/MunroRepositoryTest.java
@@ -21,9 +21,13 @@ class MunroRepositoryTest {
     }
 
     @Test
-    void getMunroWithName() {
+    void findFirstMunro() {
         List<Munro> foundMunro = munroRepository.find();
         assertNotEquals(0, foundMunro.size());
-        assertEquals("Ben Chonzie", foundMunro.get(0).getName());
+        Munro firstMunro = foundMunro.get(0);
+        assertEquals("Ben Chonzie", firstMunro.getName());
+        assertEquals(931, firstMunro.getHeight());
+        assertEquals("MUN", firstMunro.getCategory());
+        assertEquals("NN773308", firstMunro.getGridReference());
     }
 }

--- a/src/test/java/in/samspa/munroapi/MunroRepositoryTest.java
+++ b/src/test/java/in/samspa/munroapi/MunroRepositoryTest.java
@@ -1,0 +1,22 @@
+package in.samspa.munroapi;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MunroRepositoryTest {
+
+    @BeforeEach
+    void init() {
+        munroRepository = new MunroRepository();
+    }
+
+    MunroRepository munroRepository;
+
+    @Test
+    void contextLoads() {
+        munroRepository.find();
+    }
+}


### PR DESCRIPTION
Loads CSV data straight into Munro object. I was figuring out how it works as I went along so I didn't follow best TDD practices here. The CSV to Bean functionality can be extracted out which will allow for more testing with mocked data.